### PR TITLE
Ensure file line endings are Unix style for MINGW (20201007)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,28 @@
+# Set the default behavior to unix-style line ending, needed for MINGW on Windows
+* text eol=lf
+
+# Explicitly declare text files with the default behavior (should be unnecessary)
+*.cpp text
+*.CPP text
+*.c text
+*.h text
+*.H text
+*.am text
+*.in text
+*.m4 text
+*.rc text
+*.sh text
+configure text
+config.* text
+
+# Declare files that need CRLF line endings on checkout.
+*.sln text eol=crlf
+*.vcproj text eol=crlf
+*.vsprops text eol=crlf
+*.rules text eol=crlf
+*.bat text eol=crlf
+
+# Denote all files that are truly binary and should not be modified.
+*.ico binary
+*.wav binary
+*.mp3 binary


### PR DESCRIPTION
This may need a merge to the Bloom branch as well.  I think it's needed on the master branch
because that's what an initial clone opens.